### PR TITLE
add Go 1.23 to the build matrix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,6 +10,7 @@ jobs:
     strategy:
       matrix:
         go:
+          - "1.23"
           - "1.22"
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the testing matrix to include Go version "1.23" alongside "1.22" for enhanced testing coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->