### PR TITLE
drop support of Go 1.23

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,8 +12,6 @@ jobs:
         go:
           - "1.25"
           - "1.24"
-          - "1.23"
-          - "1.22"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Go


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI test configuration to run against Go versions 1.24 and 1.25 only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->