### PR TITLE
add Go 1.26 to the test matrix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,8 +8,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         go:
+          - "1.26"
           - "1.25"
           - "1.24"
     steps:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test matrix configuration to include Go 1.26 testing alongside existing versions
  * Modified test execution to continue across all version combinations when individual tests fail

<!-- end of auto-generated comment: release notes by coderabbit.ai -->