### PR TITLE
add MySQL 9.7 and 8.4 to the test matrix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,6 +14,10 @@ jobs:
           - "1.26"
           - "1.25"
           - "1.24"
+        mysql:
+          - "9.7"
+          - "8.4"
+          - "8.0"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Go
@@ -24,7 +28,7 @@ jobs:
       - name: setup MySQL
         uses: shogo82148/actions-setup-mysql@9c42ca180d5f1dd4dceb54c23c5eda0384f4d265 # v1.50.0
         with:
-          mysql-version: "8.0"
+          mysql-version: ${{ matrix.mysql }}
           root-password: verysecret
 
       - name: Run tests


### PR DESCRIPTION
MySQL 9.7 and 8.4 are Long Term Support versions.
We also support these versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage to validate compatibility with multiple MySQL database versions (9.7, 8.4, 8.0), ensuring broader database compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->