### PR TITLE
Add support for empty DDL in database initialization and new test case

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -20,7 +20,8 @@ type Pool struct {
 	// MySQLConfig is the configuration for the MySQL connection.
 	MySQLConfig *mysql.Config
 
-	// DDL is Data Definition.
+	// DDL is Data Definition Language statements to initialize the database.
+	// If DDL is empty, the database will not be initialized.
 	DDL string
 
 	mu      sync.Mutex
@@ -141,6 +142,11 @@ func (p *Pool) createDB(ctx context.Context) (string, error) {
 }
 
 func (p *Pool) initDB(ctx context.Context, dbName string) error {
+	if p.DDL == "" {
+		// If DDL is empty, do nothing.
+		return nil
+	}
+
 	// Open a new connection to the database.
 	cfg := p.MySQLConfig.Clone()
 	cfg.DBName = dbName

--- a/pool_test.go
+++ b/pool_test.go
@@ -35,8 +35,7 @@ func newMySQLConfig(t *testing.T) *mysql.Config {
 func TestPool_EmptyDDL(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	cfg := newMySQLConfig(t)
 	p := &Pool{

--- a/pool_test.go
+++ b/pool_test.go
@@ -33,6 +33,29 @@ func newMySQLConfig(t *testing.T) *mysql.Config {
 	return cfg
 }
 
+func TestPool_EmptyDDL(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg := newMySQLConfig(t)
+	p := &Pool{
+		MySQLConfig: cfg,
+	}
+
+	// get the database from the pool
+	db, err := p.Get(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p.Put(db)
+
+	if err := p.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestPool_CleanupDB(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pools with no initialization SQL now skip database initialization cleanly.
  * Database connections are not opened when initialization is not configured.

* **Tests**
  * Added coverage to verify that pools without initialization SQL can be used and closed successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->